### PR TITLE
Pf 358 solucion colegios sin nombre

### DIFF
--- a/profefolio/Controllers/ColegiosController.cs
+++ b/profefolio/Controllers/ColegiosController.cs
@@ -158,6 +158,14 @@ namespace profefolio.Controllers
                 {
                     return BadRequest("Persona no válida");
                 }
+                //verificar si el id ya fue asignado a un colegio
+                //"El administrador ya esta asignado a un colegio."
+                //buscar en la tabla colegios ese id administrador
+                var verificarAdmin = await _colegioService.FindAdminColegio(colegio.PersonaId);
+                if (verificarAdmin != null)
+                {
+                    return BadRequest($"El administrador ya esta asignado a un colegio.");
+                }
 
                 // Verificar duplicados con nombre de colegio e id iguales
                 var verificar = await _colegioService.FindByNamePerson(colegio.Nombre, colegio.PersonaId);

--- a/profefolio/Repository/IColegio.cs
+++ b/profefolio/Repository/IColegio.cs
@@ -13,4 +13,5 @@ public interface IColegio : IRepository<Colegio>
     Task<Colegio> FindByIdAdmin(string id);
     Task<bool> ExistOtherWithEqualName(string newName, int id);
     Task<bool> ExistAdminInOtherColegio(string idNewAdmin, int idColegio);
+    Task<Colegio> FindAdminColegio(string idAdmin);
 }

--- a/profefolio/Repository/IColegio.cs
+++ b/profefolio/Repository/IColegio.cs
@@ -14,4 +14,5 @@ public interface IColegio : IRepository<Colegio>
     Task<bool> ExistOtherWithEqualName(string newName, int id);
     Task<bool> ExistAdminInOtherColegio(string idNewAdmin, int idColegio);
     Task<Colegio> FindAdminColegio(string idAdmin);
+    Task<Colegio> FindAdminColegioDeleted(string idAdmin);
 }

--- a/profefolio/Services/ColegiosService.cs
+++ b/profefolio/Services/ColegiosService.cs
@@ -41,6 +41,17 @@ public class ColegiosService : IColegio
             .Where(p => !p.Deleted && p.Nombre == name)
             .FirstOrDefaultAsync();
     }
+    /**
+    * Verificar si el admin ya fue asignado a un colegio.
+    * Si fue asignado se retorna el colegio.
+    * Si aun no fue asignado Colegio = null
+    **/
+    public async Task<Colegio> FindAdminColegio(string idAdmin)
+    {
+        return await _dbContext.Colegios
+            .Where(p => !p.Deleted && p.PersonaId == idAdmin)
+            .FirstOrDefaultAsync();
+    }
 
     public async Task<Persona> FindByPerson(string id)
     {

--- a/profefolio/Services/ColegiosService.cs
+++ b/profefolio/Services/ColegiosService.cs
@@ -53,6 +53,18 @@ public class ColegiosService : IColegio
             .FirstOrDefaultAsync();
     }
 
+    /**
+    * Verificar si el admin ya fue asignado a un colegio eliminado.
+    * Si fue asignado se retorna el colegio.
+    * Si aun no fue asignado Colegio = null
+    **/
+    public async Task<Colegio> FindAdminColegioDeleted(string idAdmin)
+    {
+        return await _dbContext.Colegios
+            .Where(p => p.Deleted && p.PersonaId == idAdmin)
+            .FirstOrDefaultAsync();
+    }
+
     public async Task<Persona> FindByPerson(string id)
     {
         var query = await _userManager.Users

--- a/profefolio/appsettings.json
+++ b/profefolio/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Context": "User ID =postgres; Password = 1loli2; Host = localhost; Port = 5432; Database=profefolio"
+    "Context": "User ID =postgres@profefolio-dev; Password = Profefolio_dev; Host = profefolio-dev.postgres.database.azure.com; Port = 5432; Database=PF-test"
   },
   "Logging": {
     "LogLevel": {

--- a/profefolio/appsettings.json
+++ b/profefolio/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Context": "User ID =postgres@profefolio-dev; Password = Profefolio_dev; Host = profefolio-dev.postgres.database.azure.com; Port = 5432; Database=PF-test"
+    "Context": "User ID =postgres; Password = 1loli2; Host = localhost; Port = 5432; Database=profefolio"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Se uso string.IsNullOrWhiteSpace() para verificar si el nombre del colegio es nulo, vacío o solo contiene espacios.
Se solucionan un problema adicional: El problema era que indicaba llave duplicada cuando se intentaba agregar un id admin que estaba asignado a un colegio que fue eliminado recientemente, el colegio estaba en Deleted=true. Para esto se busca en la tabla Colegios el id Admin y si existe en un colegio eliminado con ese id Admin,  se actualiza ese registro con el nuevo nombre de colegio.
Otro problema fue que se indicaba error 500 cuando se intentaba agregar un id Admin que ya fue asignado a otro colegio. Ahora se devuelve bad request http 400 - "El administrador ya fue asignado a un colegio."
