### PR TITLE
Pf 371 get all admin no asignados

### DIFF
--- a/profefolio/Controllers/ColegiosController.cs
+++ b/profefolio/Controllers/ColegiosController.cs
@@ -214,9 +214,16 @@ namespace profefolio.Controllers
         [HttpGet("administradores/noAsignados")]
         public async Task<ActionResult<List<AdministradorDTO>>> GetAdministradoresNoAsignados()
         {
-            var administradoresNoAsignados = await _colegioService.GetAdministradoresNoAsignados();
-            var administradoresDTO = _mapper.Map<List<AdministradorDTO>>(administradoresNoAsignados);
-            return Ok(administradoresDTO);
+            try
+            {
+                var administradoresNoAsignados = await _colegioService.GetAdministradoresNoAsignados();
+                var administradoresDTO = _mapper.Map<List<AdministradorDTO>>(administradoresNoAsignados);
+                return Ok(administradoresDTO);
+            }
+            catch (Exception e)
+            {
+                return BadRequest("Error al obtener los administradores no asignados.");
+            }
         }
 
 

--- a/profefolio/Controllers/ColegiosController.cs
+++ b/profefolio/Controllers/ColegiosController.cs
@@ -211,7 +211,7 @@ namespace profefolio.Controllers
             return Ok();
         }
 
-        [HttpGet("administradores/noasignados")]
+        [HttpGet("administradores/noAsignados")]
         public async Task<ActionResult<List<AdministradorDTO>>> GetAdministradoresNoAsignados()
         {
             var administradoresNoAsignados = await _colegioService.GetAdministradoresNoAsignados();

--- a/profefolio/Controllers/ColegiosController.cs
+++ b/profefolio/Controllers/ColegiosController.cs
@@ -107,7 +107,8 @@ namespace profefolio.Controllers
 
             // verificar que el id del administrador nuevo no este asugnado a un colegio distinto al actual
             var existeAdmin = await _colegioService.ExistAdminInOtherColegio(colegio.PersonaId, id);
-            if(existeAdmin){
+            if (existeAdmin)
+            {
                 return BadRequest("El administrador ya esta asignado a otro colegio.");
             }
 
@@ -208,6 +209,14 @@ namespace profefolio.Controllers
             await _colegioService.Save();
 
             return Ok();
+        }
+
+        [HttpGet("administradores/noasignados")]
+        public async Task<ActionResult<List<AdministradorDTO>>> GetAdministradoresNoAsignados()
+        {
+            var administradoresNoAsignados = await _colegioService.GetAdministradoresNoAsignados();
+            var administradoresDTO = _mapper.Map<List<AdministradorDTO>>(administradoresNoAsignados);
+            return Ok(administradoresDTO);
         }
 
 

--- a/profefolio/Helpers/Mappers/ColegioMapper.cs
+++ b/profefolio/Helpers/Mappers/ColegioMapper.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using profefolio.Models.DTOs.Colegio;
 using profefolio.Models.Entities;
+using profefolio.Models.DTOs;
 
 namespace profefolio.Helpers.Mappers;
 
@@ -69,5 +70,23 @@ public class ColegioMapper : Profile
                 opt => opt.MapFrom(v => v.personas.Apellido))
             .ForMember(dest => dest.PersonaId,
                 opt => opt.MapFrom(v => v.PersonaId));
+
+         CreateMap<Persona, AdministradorDTO>()
+            .ForMember(dest => dest.Nombre,
+                        opt => opt.MapFrom(src => src.Nombre))
+            .ForMember(dest => dest.Apellido,
+                        opt => opt.MapFrom(src => src.Apellido))
+            .ForMember(dest => dest.Id,
+                        opt => opt.MapFrom(src => src.Id));
+
+        CreateMap<AdministradorDTO, Persona>()
+            .ForMember(dest => dest.Id,
+                opt => opt.Ignore())
+            .ForMember(dest => dest.Created,
+                opt => opt.MapFrom(src => DateTime.Now))
+            .ForMember(dest => dest.Modified,
+                opt => opt.Ignore())
+            .ForMember(dest => dest.ModifiedBy,
+                opt => opt.Ignore());
     }
 }

--- a/profefolio/Models/DTOs/Administrador/AdministradorDTO.cs
+++ b/profefolio/Models/DTOs/Administrador/AdministradorDTO.cs
@@ -1,0 +1,18 @@
+namespace profefolio.Models.DTOs;
+
+public class AdministradorDTO
+{
+    public string Id { get; set; }
+    public string? Nombre
+    {
+        get;
+        set;
+    }
+    public string? Apellido
+    {
+        get;
+        set;
+    }
+
+   
+}

--- a/profefolio/Repository/IColegio.cs
+++ b/profefolio/Repository/IColegio.cs
@@ -13,4 +13,5 @@ public interface IColegio : IRepository<Colegio>
     Task<Colegio> FindByIdAdmin(string id);
     Task<bool> ExistOtherWithEqualName(string newName, int id);
     Task<bool> ExistAdminInOtherColegio(string idNewAdmin, int idColegio);
+    Task<List<Persona>> GetAdministradoresNoAsignados();
 }

--- a/profefolio/Services/ColegiosService.cs
+++ b/profefolio/Services/ColegiosService.cs
@@ -164,23 +164,27 @@ public class ColegiosService : IColegio
     }
     /*
     * Obtener la lista de todos los administradores que no están asignados a ningún colegio. 
+    * Se devuelve correctamente el administrador eliminado de la relación en la lista de 
+    * administradores no asignados.
     */
     public async Task<List<Persona>> GetAdministradoresNoAsignados()
     {
         var administradoresAsignados = await _dbContext.Colegios
             .Select(c => c.PersonaId)
-            .Distinct()
             .ToListAsync();
 
         var administradoresRol = await _userManager.GetUsersInRoleAsync("Administrador de Colegio");
         var administradoresRolIds = administradoresRol.Select(a => a.Id);
 
         var administradoresNoAsignados = await _dbContext.Users
-            .Where(a => !administradoresAsignados.Contains(a.Id) && administradoresRolIds.Contains(a.Id))
+            .Where(a => administradoresRolIds.Contains(a.Id))
             .ToListAsync();
+
+        administradoresNoAsignados.RemoveAll(a => administradoresAsignados.Contains(a.Id));
 
         return administradoresNoAsignados;
     }
+
 
 
 }

--- a/profefolio/Services/ColegiosService.cs
+++ b/profefolio/Services/ColegiosService.cs
@@ -170,6 +170,7 @@ public class ColegiosService : IColegio
     public async Task<List<Persona>> GetAdministradoresNoAsignados()
     {
         var administradoresAsignados = await _dbContext.Colegios
+            .Where(c => !c.Deleted)
             .Select(c => c.PersonaId)
             .ToListAsync();
 
@@ -177,10 +178,8 @@ public class ColegiosService : IColegio
         var administradoresRolIds = administradoresRol.Select(a => a.Id);
 
         var administradoresNoAsignados = await _dbContext.Users
-            .Where(a => administradoresRolIds.Contains(a.Id))
+            .Where(a => !administradoresAsignados.Contains(a.Id) && administradoresRolIds.Contains(a.Id))
             .ToListAsync();
-
-        administradoresNoAsignados.RemoveAll(a => administradoresAsignados.Contains(a.Id));
 
         return administradoresNoAsignados;
     }

--- a/profefolio/Services/ColegiosService.cs
+++ b/profefolio/Services/ColegiosService.cs
@@ -55,12 +55,12 @@ public class ColegiosService : IColegio
         return query;
     }
 
-      public async Task<int> FindByPersonRol(string id)
+    public async Task<int> FindByPersonRol(string id)
     {
         var query = await _userManager.GetUsersInRoleAsync("Administrador de Colegio");
 
         return query
-            .Count(p => !p.Deleted  && p.Id == id);
+            .Count(p => !p.Deleted && p.Id == id);
     }
 
     /*
@@ -147,8 +147,8 @@ public class ColegiosService : IColegio
     public async Task<Colegio> FindByIdAdmin(string id)
     {
         return await _dbContext.Colegios.Include(p => p.personas).FirstOrDefaultAsync(
-                    c => !c.Deleted 
-                    && c.PersonaId != null 
+                    c => !c.Deleted
+                    && c.PersonaId != null
                     && id.Equals(c.PersonaId)
                     && !c.personas.Deleted);
     }
@@ -162,4 +162,21 @@ public class ColegiosService : IColegio
     {
         return await _dbContext.Colegios.AnyAsync(a => !a.Deleted && a.Id != idColegio && idNewAdmin.Equals(a.PersonaId));
     }
+    /*
+    * Obtener la lista de todos los administradores que no están asignados a ningún colegio. 
+    */
+    public async Task<List<Persona>> GetAdministradoresNoAsignados()
+    {
+        var administradoresAsignados = await _dbContext.Colegios
+            .Select(c => c.PersonaId)
+            .Distinct()
+            .ToListAsync();
+
+        var administradoresNoAsignados = await _dbContext.Users
+            .Where(a => !administradoresAsignados.Contains(a.Id))
+            .ToListAsync();
+
+        return administradoresNoAsignados;
+    }
+
 }

--- a/profefolio/Services/ColegiosService.cs
+++ b/profefolio/Services/ColegiosService.cs
@@ -178,6 +178,7 @@ public class ColegiosService : IColegio
         var administradoresRolIds = administradoresRol.Select(a => a.Id);
 
         var administradoresNoAsignados = await _dbContext.Users
+            .Where(c => !c.Deleted)
             .Where(a => !administradoresAsignados.Contains(a.Id) && administradoresRolIds.Contains(a.Id))
             .ToListAsync();
 

--- a/profefolio/Services/ColegiosService.cs
+++ b/profefolio/Services/ColegiosService.cs
@@ -172,11 +172,15 @@ public class ColegiosService : IColegio
             .Distinct()
             .ToListAsync();
 
+        var administradoresRol = await _userManager.GetUsersInRoleAsync("Administrador de Colegio");
+        var administradoresRolIds = administradoresRol.Select(a => a.Id);
+
         var administradoresNoAsignados = await _dbContext.Users
-            .Where(a => !administradoresAsignados.Contains(a.Id))
+            .Where(a => !administradoresAsignados.Contains(a.Id) && administradoresRolIds.Contains(a.Id))
             .ToListAsync();
 
         return administradoresNoAsignados;
     }
+
 
 }

--- a/profefolio/appsettings.json
+++ b/profefolio/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Context": "User ID =postgres; Password = 1loli2; Host = localhost; Port = 5432; Database=profefolio"
+    "Context": "User ID =postgres@profefolio-dev; Password = Profefolio_dev; Host = profefolio-dev.postgres.database.azure.com; Port = 5432; Database=PF-test"
   },
   "Logging": {
     "LogLevel": {

--- a/profefolio/appsettings.json
+++ b/profefolio/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Context": "User ID =postgres@profefolio-dev; Password = Profefolio_dev; Host = profefolio-dev.postgres.database.azure.com; Port = 5432; Database=PF-test"
+    "Context": "User ID =postgres; Password = 1loli2; Host = localhost; Port = 5432; Database=profefolio"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
se implementa get all para obtener todos los administradores no asignados a un colegio.
se verifica que sea del rol "Administrador de Colegio".
se traen administradores que fueron asignados a un colegio pero la relación fue eliminada, osea, Deleted=true, en la tabla Colegios.
no se traen administradores recientemente eliminados de la tabla Users.